### PR TITLE
Support packages, fix logpath extension when not using syslog, support tokumx instance name

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,13 @@ default['mongodb']['download']['checksum'] = '16077e3952c8377d31eaf65da3b5ee09f0
 default['mongodb']['download']['host'] = 'fastdl.mongodb.org'
 default['mongodb']['download']['subfolder'] = 'linux/'
 
+# override both 'distro' and 'package_name' to install from a package
+# instead of the above tarballs. example:
+#   distro = 'mongo'
+#   package_name = 'mongodb-10gen'
+default[:mongodb][:distro] = nil
+default[:mongodb][:package_name] = nil
+default[:mongodb][:package_version] = nil
 
 ################################################################################
 # Generic configuration (will be the same for all instances on this node)
@@ -35,7 +42,7 @@ default['mongodb']['group_id'] = 3500
 default['mongodb']['group'] = 'mongodb'
 
 # Paths
-default['mongodb']['log_dir'] = '/var/log/mongo'
+default['mongodb']['log_dir'] = '/var/log'
 # we'll create a new folder in these paths for each instance
 default['mongodb']['data_dir'] = '/var/lib/mongo_data'
 default['mongodb']['journal_dir'] = '/var/lib/mongo_journal'

--- a/providers/mongod.rb
+++ b/providers/mongod.rb
@@ -18,13 +18,16 @@
 #
 
 action :create do
-  instance_name = if new_resource.name == "default" then "mongod"
+  instance_name = if node[:mongodb][:distro] == "tokumx" then "tokumx"
+                  elsif new_resource.name == "default" then "mongod"
                   else "mongod-#{new_resource.name}"
                   end
 
   Chef::Log.info "Configuring MongoDB instance '#{instance_name}'..."
 
-  config_file = "/etc/mongodb/#{instance_name}.conf"
+  config_file = if node[:mongodb][:distro] == "tokumx" then "/etc/tokumx.conf"
+                else "/etc/mongodb/#{instance_name}.conf"
+                end
 
   template config_file do
     source "mongod.conf.erb"
@@ -51,6 +54,14 @@ action :create do
 
   # Journal dir
   directory ::File.join(node['mongodb']['journal_dir'], instance_name) do
+    owner node['mongodb']['user']
+    group node['mongodb']['group']
+    mode  '755'
+    recursive true
+  end
+
+  # Log dir
+  directory ::File.join(node['mongodb']['log_dir'], instance_name) do
     owner node['mongodb']['user']
     group node['mongodb']['group']
     mode  '755'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,15 +38,18 @@ end
 ################################################################################
 # Set up Mongo user, group and folders
 
-group node['mongodb']['group'] do
-  gid node['mongodb']['group_id']
-  action :create
-end
+# User and group are already created when installing from a package.
+if node['mongodb']['package_name'] == nil
+  group node['mongodb']['group'] do
+    gid node['mongodb']['group_id']
+    action :create
+  end
 
-user node['mongodb']['user'] do
-  gid   node['mongodb']['group_id']
-  shell '/bin/false' # no login
-  # no home dir
+  user node['mongodb']['user'] do
+    gid   node['mongodb']['group_id']
+    shell '/bin/false' # no login
+    # no home dir
+  end
 end
 
 directory '/etc/mongodb' do
@@ -69,31 +72,37 @@ if node['mongodb']['auth_enabled'] && node['mongodb']['auth_keyfile'] == '/etc/m
   end
 end
 
-
 ################################################################################
 # Download MongoDB release - NOTE: This won't configure and start an instance
 
-mongo_binaries = [
-  'bsondump',
-  'mongo',
-  'mongod',
-  'mongodump',
-  'mongoexport',
-  'mongofiles',
-  'mongoimport',
-  'mongooplog',
-  'mongoperf',
-  'mongorestore',
-  'mongos',
-  'mongosniff',
-  'mongostat',
-  'mongotop'
-]
+if node['mongodb']['package_name']
+  package node[:mongodb][:package_name] do
+    action :install
+    version node[:mongodb][:package_version]
+  end
+else
+  mongo_binaries = [
+    'bsondump',
+    'mongo',
+    'mongod',
+    'mongodump',
+    'mongoexport',
+    'mongofiles',
+    'mongoimport',
+    'mongooplog',
+    'mongoperf',
+    'mongorestore',
+    'mongos',
+    'mongosniff',
+    'mongostat',
+    'mongotop'
+  ]
 
-ark "mongodb" do
-  url node['mongodb']['download']['src']
-  version node['mongodb']['download']['version']
-  checksum node['mongodb']['download']['checksum']
-  has_binaries mongo_binaries.map{|b| "bin/#{b}"}
-  action :install
+  ark "mongodb" do
+    url node['mongodb']['download']['src']
+    version node['mongodb']['download']['version']
+    checksum node['mongodb']['download']['checksum']
+    has_binaries mongo_binaries.map{|b| "bin/#{b}"}
+    action :install
+  end
 end

--- a/templates/default/mongod.conf.erb
+++ b/templates/default/mongod.conf.erb
@@ -11,7 +11,7 @@ dbpath = <%= @db_path %>
 <% if node['mongodb']['syslog'] == true %>
 syslog = true
 <% else %>
-logpath = <%= node['mongodb']['log_dir'] %>/<%= @instance_name %>
+logpath = <%= node['mongodb']['log_dir'] %>/<%= @instance_name %>/<%= @instance_name %>.log
 logappend = <%= node['mongodb']['log_append'] %>
 <% end %>
 <% if node['mongodb']['log_cpu'] %>cpu = <%= node['mongodb']['log_cpu'] %><% end %>

--- a/templates/default/mongod.upstart.erb
+++ b/templates/default/mongod.upstart.erb
@@ -14,7 +14,7 @@ respawn
 limit nofile <%= node['mongodb']['open_file_limit'] %> <%= node['mongodb']['open_file_limit'] %>
 
 # Start the process
-exec start-stop-daemon --start --chuid <%= node['mongodb']['user'] %> --make-pidfile --pidfile /var/run/<%= @instance_name %>.pid --exec /usr/local/bin/mongod -- -f <%= @config_file %>
+exec start-stop-daemon --start --chuid <%= node['mongodb']['user'] %> --make-pidfile --pidfile /var/run/<%= @instance_name %>.pid --exec <% if node['mongodb']['package_name'] %>/usr/<% else %>/usr/local/<% end %>bin/mongod -- -f <%= @config_file %>
 
 # Clean up after stopping the process
 post-stop script


### PR DESCRIPTION
- Store logs in /var/log/XYZ/XYZ.log
- Look for the mongod binary in /usr/bin if installing from packages
- Support tokumx (http://github.com/Tokutek/mongo) as a supported mongo distrubtion, service name tokumx.
