### PR TITLE
Fix for replicaset initiate

### DIFF
--- a/providers/replica_set.rb
+++ b/providers/replica_set.rb
@@ -60,7 +60,7 @@ action :create do
       replica_set_initiated = true
     rescue ::Mongo::OperationFailure => ex
       # unless it's telling us to initiate the replica set
-      unless ex.message.include? 'run rs.initiate'
+      unless ex.message.include?('run rs.initiate') || ex.message.include?("can't get local.system.replset config from self or any seed")
         raise # re-raise the error - we want to know about it
       end
     end


### PR DESCRIPTION
On Mongo 2.6.2, I'm getting the following error when initiating replicaset with 1 node.

```
Mongo::OperationFailure
-----------------------
Database command 'replSetGetStatus' failed: can't get local.system.replset config from self or any seed (EMPTYCONFIG)
```

This fix checks for the error message and allows replicaset to be initiated.
